### PR TITLE
Fixing a highlight disfunction and adding aggregation operators

### DIFF
--- a/grammars/mongodb (javascript).cson
+++ b/grammars/mongodb (javascript).cson
@@ -7,8 +7,8 @@ foldingStopMarker: "^\\s*\\}"
 name: "mongoDB (JavaScript)"
 patterns: [
   {
-    begin: "\\{"
-    end: "\\}"
+    begin: "\\.(update|find|remove|insert)\\("
+    end: "\\)\\;"
     patterns: [
       {
         include: "#keywords"

--- a/grammars/mongodb (javascript).cson
+++ b/grammars/mongodb (javascript).cson
@@ -45,7 +45,7 @@ repository:
     match: "\"\\w+(\\.\\w+)*\""
     name: "string.quoted.double.js.mongodb"
   keywords:
-    match: "\\$(gt|lt|in|nin|all|mod|exists|type|elemMatch|not|where|or|inc|set|unset|push|pushAll|addToSet|each|pop|pull|pullAll|size|ne|gte|lte)\\s*:"
+    match: "\\$(gt|lt|in|nin|all|mod|exists|type|elemMatch|not|where|or|inc|set|unset|push|pushAll|addToSet|each|pop|pull|pullAll|size|ne|gte|lte|cond|if|then|else)\\s*:"
     name: "keyword.operator.js.mongodb"
   rawKeys:
     match: "\\w+(\\.\\w+)*\\s*:"

--- a/grammars/mongodb (javascript).cson
+++ b/grammars/mongodb (javascript).cson
@@ -45,7 +45,7 @@ repository:
     match: "\"\\w+(\\.\\w+)*\""
     name: "string.quoted.double.js.mongodb"
   keywords:
-    match: "\\$(gt|lt|in|nin|all|mod|exists|type|elemMatch|not|where|or|inc|set|unset|push|pushAll|addToSet|each|pop|pull|pullAll|size|ne|gte|lte|cond|if|then|else)\\s*:"
+    match: "\\$(gt|lt|in|nin|all|mod|exists|type|elemMatch|not|where|or|inc|set|unset|push|pushAll|addToSet|each|pop|pull|pullAll|size|ne|gte|lte|cond|dateToString|if|ifNull|then|else)\\s*:"
     name: "keyword.operator.js.mongodb"
   rawKeys:
     match: "\\w+(\\.\\w+)*\\s*:"

--- a/grammars/mongodb (javascript).cson
+++ b/grammars/mongodb (javascript).cson
@@ -45,7 +45,7 @@ repository:
     match: "\"\\w+(\\.\\w+)*\""
     name: "string.quoted.double.js.mongodb"
   keywords:
-    match: "(\\$(gt|lt|in|nin|all|mod|exists|type|elemMatch|not|where|or|inc|set|unset|push|pushAll|addToSet|each|pop|pull|pullAll|size|ne|gte|lte|cond|dateToString|if|ifNull|then|else)\\s*|if|then|else):"
+    match: "(\\$(gt|lt|in|nin|all|mod|exists|type|elemMatch|not|where|or|inc|set|unset|push|pushAll|addToSet|each|pop|pull|pullAll|size|ne|gte|lte|cond|dateToString|if|ifNull)\\s*|if|then|else):"
     name: "keyword.operator.js.mongodb"
   rawKeys:
     match: "\\w+(\\.\\w+)*\\s*:"

--- a/grammars/mongodb (javascript).cson
+++ b/grammars/mongodb (javascript).cson
@@ -7,7 +7,7 @@ foldingStopMarker: "^\\s*\\}"
 name: "mongoDB (JavaScript)"
 patterns: [
   {
-    begin: "\\.(update|find|remove|insert)\\("
+    begin: "\\.(update|find|findOne|findAndModify|remove|insert|aggregate)\\("
     end: "\\)\\;"
     patterns: [
       {
@@ -45,7 +45,7 @@ repository:
     match: "\"\\w+(\\.\\w+)*\""
     name: "string.quoted.double.js.mongodb"
   keywords:
-    match: "\\$(gt|lt|in|nin|all|mod|exists|type|elemMatch|not|where|or|inc|set|unset|push|pushAll|addToSet|each|pop|pull|pullAll|size|ne|gte|lte|cond|dateToString|if|ifNull|then|else)\\s*:"
+    match: "(\\$(gt|lt|in|nin|all|mod|exists|type|elemMatch|not|where|or|inc|set|unset|push|pushAll|addToSet|each|pop|pull|pullAll|size|ne|gte|lte|cond|dateToString|if|ifNull|then|else)\\s*|if|then|else):"
     name: "keyword.operator.js.mongodb"
   rawKeys:
     match: "\\w+(\\.\\w+)*\\s*:"

--- a/grammars/mongodb (javascript).cson
+++ b/grammars/mongodb (javascript).cson
@@ -8,7 +8,7 @@ name: "mongoDB (JavaScript)"
 patterns: [
   {
     begin: "\\.(update|find|findOne|findAndModify|remove|insert|aggregate)\\("
-    end: "\\)\\;"
+    end: "\\)[[^\s]+]*(\r\n|\n\r|\r|\n)+"
     patterns: [
       {
         include: "#keywords"


### PR DESCRIPTION
- There is a bug which breaks the highlight after you close an inner object. e.g.
  {$pull: { me: 1 }, $push: { me: 2 }}
  the second won't be highlightted because } been spotted.
  Alternative to start { and stop } I replaced with the Javascript functions and end of line as the "stop" of the highlight.
- Added highlight for conditionals
  { $cond: { if: { }, then: { }, else: { } }
  $cond, if, then and else will be highlighted in different color than other key names.
- Added highlight for some more aggregation operators
