### PR TITLE
Fixed end of a parsing

### DIFF
--- a/grammars/mongodb (javascript).cson
+++ b/grammars/mongodb (javascript).cson
@@ -8,7 +8,7 @@ name: "mongoDB (JavaScript)"
 patterns: [
   {
     begin: "\\.(update|find|findOne|findAndModify|remove|insert|aggregate)\\("
-    end: "\\)[[^\s]+]*(\r\n|\n\r|\r|\n)+"
+    end: "(\\)\\.|\\)\\;|\\)(\r\n|\n\r|\r|\n))+"
     patterns: [
       {
         include: "#keywords"
@@ -48,7 +48,7 @@ repository:
     match: "(\\$(gt|lt|in|nin|all|mod|exists|type|elemMatch|not|where|or|inc|set|unset|push|pushAll|addToSet|each|pop|pull|pullAll|size|ne|gte|lte|cond|dateToString|if|ifNull)\\s*|if|then|else):"
     name: "keyword.operator.js.mongodb"
   rawKeys:
-    match: "\\w+(\\.\\w+)*\\s*:"
+    match: "[\\sa-zA-Z0-9_]*\\s*\:"
     name: "keyword.other.js.mongodb"
   singleQuotedKeys:
     match: "'\\w+(\\.\\w+)*'"


### PR DESCRIPTION
- After closing the function, it won't highlight anything after it which is in the same line

```
 .update({ }).limit(1).toArray(function() {})
```

 the number 1 and "function" wont' highlight.
 I fixed it on this version
- after closing ), it wouldn't highlight the arrays inside the object, couldn't figure out at first, but after playing with it around, I got it to work (O_o) (probably because of the ) and space, which claimed the end of parse and changing it made the trick ... but oh well, it works !)
